### PR TITLE
Add `telegraf_version` tag

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,6 @@ MAX_MAP_COUNT=262144
 # Access Elasitcsearch via bridge network by default
 ES_HOST=elk
 ES_PORT=9200
+
+# Telegraf version
+TELEGRAF_VERSION=1.5.0

--- a/conf/telegraf/telegraf.conf
+++ b/conf/telegraf/telegraf.conf
@@ -1,3 +1,6 @@
+[global_tags]
+  telegraf_version = "$TELEGRAF_VERSION"
+
 [agent]
   interval = "60s"
   round_interval = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,9 +45,11 @@ services:
     depends_on:
       - run-dmc
       - fluentd
-    image: telegraf:1.5.0-alpine
+    image: telegraf:${TELEGRAF_VERSION}-alpine
     container_name: telegraf
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./conf/telegraf/telegraf.conf:/etc/telegraf/telegraf.conf:ro
       - ./log/telegraf:/var/log/telegraf
+    environment:
+      - "TELEGRAF_VERSION=${TELEGRAF_VERSION}"


### PR DESCRIPTION
This request is for #3.

`docker-compose.yml` sets an environment variable `TELEGRAF_VERSION` by using the value in `.env` and `telegraf.conf` uses it for `telegraf_version` tag.
